### PR TITLE
Fix requirement checks for ByteReadChannel

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
   implementation(libs.okio)
 
   ksp(libs.moshi.codegen)
+
+  testImplementation(kotlin("test"))
 }
 
 gradlePlugin {

--- a/generator/src/main/kotlin/sh/christian/ozone/api/generator/BinaryDataType.kt
+++ b/generator/src/main/kotlin/sh/christian/ozone/api/generator/BinaryDataType.kt
@@ -14,7 +14,7 @@ sealed interface BinaryDataType : Serializable {
    * Represents binary data in XPRC calls with Ktor's ByteReadChannel.
    */
   object ByteReadChannel : BinaryDataType {
-    private fun readResolve(): Any = ByteArray
+    private fun readResolve(): Any = ByteReadChannel
   }
 }
 

--- a/generator/src/main/kotlin/sh/christian/ozone/api/generator/builder/XrpcBodyGenerator.kt
+++ b/generator/src/main/kotlin/sh/christian/ozone/api/generator/builder/XrpcBodyGenerator.kt
@@ -1,6 +1,5 @@
 package sh.christian.ozone.api.generator.builder
 
-import com.squareup.kotlinpoet.BYTE_ARRAY
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -144,7 +143,7 @@ class XrpcBodyGenerator(
         is LexiconObjectProperty.IpldType ->
           SimpleProperty(
             name = name,
-            type = BYTE_ARRAY,
+            type = environment.defaults.binaryDataType.className(),
             nullable = nullable,
             description = prop.ipld.description,
             definedDefault = null,

--- a/generator/src/main/kotlin/sh/christian/ozone/api/generator/builder/util.kt
+++ b/generator/src/main/kotlin/sh/christian/ozone/api/generator/builder/util.kt
@@ -21,6 +21,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
+import sh.christian.ozone.api.generator.BinaryDataType
 import sh.christian.ozone.api.generator.LexiconProcessingEnvironment
 import sh.christian.ozone.api.generator.TypeNames
 import sh.christian.ozone.api.generator.className
@@ -42,6 +43,8 @@ import sh.christian.ozone.api.lexicon.LexiconUserType
 import sh.christian.ozone.api.lexicon.LexiconXrpcProcedure
 import sh.christian.ozone.api.lexicon.LexiconXrpcQuery
 import sh.christian.ozone.api.lexicon.LexiconXrpcSubscription
+
+private val BYTE_READ_CHANNEL = BinaryDataType.ByteReadChannel.className()
 
 fun createClassForProperties(
   className: ClassName,
@@ -100,7 +103,16 @@ fun createDataClass(
       }
     )
     .apply {
-      val allRequirements = properties.associateWith { it.requirements }.filterValues { it.isNotEmpty() }
+      val allRequirements = properties
+        .associateWith { property ->
+          // ByteReadChannel has no `count()`, so length constraints can't be enforced inline.
+          if (property.type.copy(nullable = false) == BYTE_READ_CHANNEL) {
+            property.requirements.filter { it !is Requirement.MinLength && it !is Requirement.MaxLength }
+          } else {
+            property.requirements
+          }
+        }
+        .filterValues { it.isNotEmpty() }
       if (allRequirements.isNotEmpty()) {
         addInitializerBlock(
           buildCodeBlock {

--- a/generator/src/test/kotlin/sh/christian/ozone/api/generator/builder/ByteArrayRequirementTest.kt
+++ b/generator/src/test/kotlin/sh/christian/ozone/api/generator/builder/ByteArrayRequirementTest.kt
@@ -1,0 +1,53 @@
+package sh.christian.ozone.api.generator.builder
+
+import com.squareup.kotlinpoet.BYTE_ARRAY
+import com.squareup.kotlinpoet.ClassName
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that length requirements on `ByteArray` binary fields are still emitted as
+ * `count()`-based `require(...)` checks. This is the counterpart to [ByteReadChannelRequirementTest],
+ * which asserts those same checks are skipped for `ByteReadChannel` (a type that has no `count()`).
+ *
+ * Asserted bounds are kept under 1000 so they render verbatim — kotlinpoet inserts digit-group
+ * underscores (e.g. `1_000`) for larger literals.
+ */
+class ByteArrayRequirementTest {
+  private fun render(nullable: Boolean, vararg requirements: Requirement): String {
+    val property = SimpleProperty(
+      name = "blob",
+      type = BYTE_ARRAY,
+      nullable = nullable,
+      description = null,
+      definedDefault = null,
+      requirements = requirements.toList(),
+    )
+    return createDataClass(ClassName("com.example", "Foo"), listOf(property), null).toString()
+  }
+
+  @Test
+  fun `maxLength emits count check`() {
+    val out = render(nullable = false, Requirement.MaxLength(200L))
+    assertTrue(out.contains("require(blob.count() <= 200)"), out)
+  }
+
+  @Test
+  fun `minLength emits count check`() {
+    val out = render(nullable = false, Requirement.MinLength(5L))
+    assertTrue(out.contains("require(blob.count() >= 5)"), out)
+  }
+
+  @Test
+  fun `min and max length both emit checks`() {
+    val out = render(nullable = false, Requirement.MinLength(5L), Requirement.MaxLength(200L))
+    assertTrue(out.contains("blob.count() >= 5"), out)
+    assertTrue(out.contains("blob.count() <= 200"), out)
+  }
+
+  @Test
+  fun `nullable maxLength guards against null`() {
+    val out = render(nullable = true, Requirement.MaxLength(200L))
+    assertTrue(out.contains("require(blob == null || blob.count() <= 200)"), out)
+  }
+}

--- a/generator/src/test/kotlin/sh/christian/ozone/api/generator/builder/ByteReadChannelRequirementTest.kt
+++ b/generator/src/test/kotlin/sh/christian/ozone/api/generator/builder/ByteReadChannelRequirementTest.kt
@@ -1,0 +1,50 @@
+package sh.christian.ozone.api.generator.builder
+
+import com.squareup.kotlinpoet.BYTE_ARRAY
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeName
+import sh.christian.ozone.api.generator.BinaryDataType
+import sh.christian.ozone.api.generator.className
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards the `ByteReadChannel` length-requirement handling in [createDataClass]. `ByteReadChannel`
+ * has no `count()`, so emitting a `MaxLength`/`MinLength` `require(... .count() ...)` check for such
+ * a field would produce code that doesn't compile — those checks must be skipped, while the same
+ * checks for `ByteArray` and `List` fields (which do have `count()`) must be preserved.
+ */
+class ByteReadChannelRequirementTest {
+  private val byteReadChannel: TypeName = BinaryDataType.ByteReadChannel.className()
+
+  private fun render(type: TypeName, nullable: Boolean): String {
+    val property = SimpleProperty(
+      name = "blob",
+      type = type,
+      nullable = nullable,
+      description = null,
+      definedDefault = null,
+      requirements = listOf(Requirement.MaxLength(10_000L)),
+    )
+    return createDataClass(ClassName("com.example", "Foo"), listOf(property), null).toString()
+  }
+
+  @Test
+  fun `byteReadChannel skips count check`() =
+    assertFalse(render(byteReadChannel, nullable = false).contains(".count()"))
+
+  @Test
+  fun `nullable byteReadChannel skips count check`() =
+    assertFalse(render(byteReadChannel, nullable = true).contains(".count()"))
+
+  @Test
+  fun `byteArray still enforces count check`() =
+    assertTrue(render(BYTE_ARRAY, nullable = false).contains("blob.count()"))
+
+  @Test
+  fun `list of byteReadChannel still enforces count check`() =
+    assertTrue(render(LIST.parameterizedBy(byteReadChannel), nullable = false).contains("blob.count()"))
+}


### PR DESCRIPTION
This PR fixes 2 small bugs for `ByteReadChannel` use:

* The current codegen for requirements currently tries to enforce `minLength` and `maxLength` for `ByteReadChannel` which causes a causes a compile error as there is no `count()` method for `ByteReadChannel`. The requirement is now skipped for it.
* The configuration cache would deserialize `ByteReadChannel` as a `ByteArray` as they have identical `readResolve` return types.

The PR also adds tests for the former.